### PR TITLE
Remove pure-lockfile from toolforge.yml

### DIFF
--- a/.github/workflows/toolforge.yml
+++ b/.github/workflows/toolforge.yml
@@ -27,6 +27,6 @@ jobs:
             become capx git -C '$HOME/www/js' fetch origin
             become capx git -C '$HOME/www/js' reset --hard origin/main
             become capx git -C '$HOME/www/js' pull origin main
-            become capx webservice --mem 2G --cpu 2 node18 shell -- yarn --cwd '$HOME/www/js' install --pure-lockfile
+            become capx webservice --mem 2G --cpu 2 node18 shell -- yarn --cwd '$HOME/www/js' install
             become capx webservice --mem 2G --cpu 2 node18 shell -- yarn --cwd '$HOME/www/js' build
             become capx webservice restart


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/toolforge.yml` file. The change modifies the `yarn install` command by removing the `--pure-lockfile` option.

* [`.github/workflows/toolforge.yml`](diffhunk://#diff-c6a8c3b1b4c8eb644e0888933e1b0573743b4bc6cf52f6d69b72568bcfb7f769L30-R30): Removed the `--pure-lockfile` option from the `yarn install` command to ensure the latest versions of dependencies are installed.