### PR TITLE
Add metabase source to capacity routes

### DIFF
--- a/src/app/(auth)/capacity/components/CapacitySearch.tsx
+++ b/src/app/(auth)/capacity/components/CapacitySearch.tsx
@@ -6,8 +6,10 @@ import { useApp } from "@/contexts/AppContext";
 import BaseInput from "@/components/BaseInput";
 import { CapacityCard } from "./CapacityCard";
 import SearchIcon from "@/public/static/images/search.svg";
+import SearchIconWhite from "@/public/static/images/search_icon_white.svg";
 import { useCapacityList } from "@/hooks/useCapacityList";
 import LoadingState from "@/components/LoadingState";
+import { useTheme } from "@/contexts/ThemeContext";
 
 interface CapacitySearchProps {
   onSearchStart?: () => void;
@@ -58,6 +60,7 @@ export function CapacitySearch({
 }: CapacitySearchProps) {
   const { data: session } = useSession();
   const { language, isMobile, pageContent } = useApp();
+  const { darkMode } = useTheme();
   const [searchTerm, setSearchTerm] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [expandedCapacities, setExpandedCapacities] = useState<
@@ -145,10 +148,12 @@ export function CapacitySearch({
         value={searchTerm}
         onChange={(e) => setSearchTerm(e.target.value)}
         placeholder={pageContent["capacity-search-placeholder"]}
-        className={`w-full py-6 px-3 text-capx-dark-box-bg rounded-[16px] opacity-50 border border-capx-dark-box-bg ${
-          isMobile ? "text-[12px]" : "text-[24px]"
-        }`}
-        icon={SearchIcon}
+        className={`w-full py-6 px-3 rounded-[16px] opacity-50 ${
+          darkMode
+            ? "text-white border-white"
+            : "text-capx-dark-box-bg border-capx-dark-box-bg "
+        } ${isMobile ? "text-[12px]" : "text-[24px]"}`}
+        icon={darkMode ? SearchIconWhite : SearchIcon}
         iconPosition="right"
       />
 

--- a/src/app/api/capacity/route.ts
+++ b/src/app/api/capacity/route.ts
@@ -1,55 +1,7 @@
 import { getCapacityColor } from "@/lib/utils/capacitiesUtils";
 import axios from "axios";
 import { NextRequest, NextResponse } from "next/server";
-
-const fetchWikidata = async (codes: any, language: string) => {
-  // Continue with Wikidata query...
-  const wdCodeList = codes.map((code) => "wd:" + code.wd_code);
-  const queryText = `SELECT ?item ?itemLabel WHERE {VALUES ?item {${wdCodeList.join(
-    " "
-  )}} SERVICE wikibase:label { bd:serviceParam wikibase:language '${language},en'.}}`;
-
-  const wikidataResponse = await axios.get(
-    `https://query.wikidata.org/bigdata/namespace/wdq/sparql?format=json&query=${queryText}`
-  );
-
-  return wikidataResponse.data.results.bindings.map((wdItem) => ({
-    wd_code: wdItem.item.value.split("/").slice(-1)[0],
-    name: wdItem.itemLabel.value,
-  }));
-};
-
-const fetchMetabase = async (codes: any, language: string) => {
-  try {
-    const mbQueryText = `PREFIX wbt:<https://metabase.wikibase.cloud/prop/direct/>  
-  SELECT ?item ?itemLabel ?itemDescription ?value WHERE {  
-    VALUES ?value {${codes.map((code) => `"${code.wd_code}"`).join(" ")}}  
-    ?item wbt:P1 ?value.  
-    SERVICE wikibase:label { bd:serviceParam wikibase:language '${language},en'. }}`;
-
-    const response = await axios.post(
-      "https://metabase.wikibase.cloud/query/sparql?format=json&query=" +
-        encodeURIComponent(mbQueryText),
-      {
-        headers: {
-          "Content-Type": "application/sparql-query",
-          Accept: "application/sparql-results+json",
-          "User-Agent": "CapX/1.0",
-        },
-      }
-    );
-
-    return response.data.results.bindings.map((mbItem) => ({
-      code: codes.find((c) => c.wd_code === mbItem.value.value)?.code,
-      wd_code: mbItem.value.value,
-      name: mbItem.itemLabel.value,
-    }));
-  } catch (error) {
-    console.error("Error in fetchMetabase:", error);
-    console.error("Error stack:", error.stack);
-    return [];
-  }
-};
+import { fetchMetabase, fetchWikidata } from "@/lib/utils/capacitiesUtils";
 
 export async function GET(req: NextRequest) {
   try {

--- a/src/app/api/capacity/route.ts
+++ b/src/app/api/capacity/route.ts
@@ -1,5 +1,55 @@
+import { getCapacityColor } from "@/lib/utils/capacitiesUtils";
 import axios from "axios";
 import { NextRequest, NextResponse } from "next/server";
+
+const fetchWikidata = async (codes: any, language: string) => {
+  // Continue with Wikidata query...
+  const wdCodeList = codes.map((code) => "wd:" + code.wd_code);
+  const queryText = `SELECT ?item ?itemLabel WHERE {VALUES ?item {${wdCodeList.join(
+    " "
+  )}} SERVICE wikibase:label { bd:serviceParam wikibase:language '${language},en'.}}`;
+
+  const wikidataResponse = await axios.get(
+    `https://query.wikidata.org/bigdata/namespace/wdq/sparql?format=json&query=${queryText}`
+  );
+
+  return wikidataResponse.data.results.bindings.map((wdItem) => ({
+    wd_code: wdItem.item.value.split("/").slice(-1)[0],
+    name: wdItem.itemLabel.value,
+  }));
+};
+
+const fetchMetabase = async (codes: any, language: string) => {
+  try {
+    const mbQueryText = `PREFIX wbt:<https://metabase.wikibase.cloud/prop/direct/>  
+  SELECT ?item ?itemLabel ?itemDescription ?value WHERE {  
+    VALUES ?value {${codes.map((code) => `"${code.wd_code}"`).join(" ")}}  
+    ?item wbt:P1 ?value.  
+    SERVICE wikibase:label { bd:serviceParam wikibase:language '${language},en'. }}`;
+
+    const response = await axios.post(
+      "https://metabase.wikibase.cloud/query/sparql?format=json&query=" +
+        encodeURIComponent(mbQueryText),
+      {
+        headers: {
+          "Content-Type": "application/sparql-query",
+          Accept: "application/sparql-results+json",
+          "User-Agent": "CapX/1.0",
+        },
+      }
+    );
+
+    return response.data.results.bindings.map((mbItem) => ({
+      code: codes.find((c) => c.wd_code === mbItem.value.value)?.code,
+      wd_code: mbItem.value.value,
+      name: mbItem.itemLabel.value,
+    }));
+  } catch (error) {
+    console.error("Error in fetchMetabase:", error);
+    console.error("Error stack:", error.stack);
+    return [];
+  }
+};
 
 export async function GET(req: NextRequest) {
   try {
@@ -32,29 +82,24 @@ export async function GET(req: NextRequest) {
         code: Number(key),
         wd_code: value,
       }));
+    const metabaseResponse = await fetchMetabase(codes, language ?? "en");
 
-    // Continue with Wikidata query...
-    const wdCodeList = codes.map((code) => "wd:" + code.wd_code);
-    const queryText = `SELECT ?item ?itemLabel WHERE {VALUES ?item {${wdCodeList.join(
-      " "
-    )}} SERVICE wikibase:label { bd:serviceParam wikibase:language '${language},en'.}}`;
-
-    const wikidataResponse = await axios.get(
-      `https://query.wikidata.org/bigdata/namespace/wdq/sparql?format=json&query=${queryText}`
-    );
-
-    const organizedData = wikidataResponse.data.results.bindings.map(
-      (wdItem) => ({
-        wd_code: wdItem.item.value.split("/").slice(-1)[0],
-        name: wdItem.itemLabel.value,
-      })
-    );
+    const wikidataResponse = await fetchWikidata(codes, language ?? "en");
 
     const codesWithNames = codes.map((obj1) => {
-      const obj2 = organizedData.find((obj2) => obj2.wd_code === obj1.wd_code);
-      return obj2 ? { ...obj1, ...obj2 } : { ...obj1, name: obj1.wd_code };
-    });
+      const metabaseMatch = metabaseResponse.find(
+        (mb) => mb.wd_code === obj1.wd_code
+      );
+      const wikidataMatch = wikidataResponse.find(
+        (wd) => wd.wd_code === obj1.wd_code
+      );
 
+      return {
+        ...obj1,
+        name: metabaseMatch?.name || wikidataMatch?.name || obj1.wd_code,
+        color: getCapacityColor(obj1.code.toString()),
+      };
+    });
     return NextResponse.json(codesWithNames);
   } catch (error) {
     console.error("Error details:", error);

--- a/src/components/LoadingState.tsx
+++ b/src/components/LoadingState.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import { useTheme } from "@/contexts/ThemeContext";
 import CapxLogo from "@/public/static/images/capx_detailed_logo.svg";
-
+import CapxLogoWhite from "@/public/static/images/capx_detailed_logo_white.svg";
 export default function LoadingState() {
   const { darkMode } = useTheme();
 
@@ -16,7 +16,7 @@ export default function LoadingState() {
     >
       <div className="relative w-16 h-16">
         <Image
-          src={CapxLogo}
+          src={darkMode ? CapxLogoWhite : CapxLogo}
           alt="CAPX Logo"
           className="animate-pulse-fade"
           width={64}

--- a/src/hooks/useCapacityList.ts
+++ b/src/hooks/useCapacityList.ts
@@ -332,7 +332,6 @@ export function useCapacityList(token?: string, language: string = "pt-br") {
               }
 
               // if didnt find the parent, create a fake parent
-              console.log("Creating a fake parent for:", item.name);
               return {
                 code: item.code,
                 name: item.name,


### PR DESCRIPTION
# Enhance Capacity Page with Metabase Integration and UI Improvements

## Changes
- **Metabase Integration**: Added a new method to fetch capacity data from Metabase, using Wikidata as a fallback source when Metabase data is unavailable
- **Code Organization**: Moved Wikidata and Metabase fetch functions to the capacities-specific utils file for better code organization and maintainability
- **Dark Mode Fixes**: Resolved layout inconsistencies in dark mode on the capacities page, ensuring a consistent visual experience across themes

## Technical Details
- Implemented SPARQL queries to fetch data from Metabase's endpoint
- Added error handling and fallback mechanisms when Metabase data is not available
- Refactored the capacity data fetching logic into separate utility functions
- Fixed dark mode styling issues by adjusting color schemes and contrast ratios

## Testing
- Verify that capacity data is correctly fetched from Metabase
- Confirm fallback to Wikidata works when Metabase data is not available
- Ensure dark mode displays correctly with no visual inconsistencies
- Test different language settings for capacity names

## Impact
This change improves data sourcing reliability by prioritizing Metabase while maintaining Wikidata as a backup, and enhances the user experience with consistent dark mode styling.