### PR TITLE
Update release-on-version-change.yml

### DIFF
--- a/.github/workflows/release-on-version-change.yml
+++ b/.github/workflows/release-on-version-change.yml
@@ -31,7 +31,7 @@ jobs:
           NEW_VERSION=$(jq -r '.version' package.json)
           if [ "$PREV_VERSION" = "$NEW_VERSION" ]; then
             echo "No version change detected. Exiting."
-            exit 0
+            exit 1
           fi
           echo "version=$NEW_VERSION" >> $GITHUB_ENV
 


### PR DESCRIPTION
This pull request modifies the behavior of the release workflow to ensure it exits with a non-zero status code when no version change is detected. This change improves the reliability of the workflow by signaling an error in such cases.

* [`.github/workflows/release-on-version-change.yml`](diffhunk://#diff-d1dde5893f79cd0e55572a62ccdbcdb2cf619e0c8e85f6a425527672c3ba4546L34-R34): Changed the exit code from `0` to `1` when no version change is detected, ensuring the workflow fails explicitly in this scenario.