### PR TITLE
Fix lets connect integration: avoid duplicated, fix language proficiency

### DIFF
--- a/src/app/(auth)/profile/edit/components/ProfileEditDesktopView.tsx
+++ b/src/app/(auth)/profile/edit/components/ProfileEditDesktopView.tsx
@@ -71,6 +71,7 @@ import { useState } from "react";
 import AvatarSelectionPopup from "../../components/AvatarSelectionPopup";
 import LetsConnectPopup from "@/components/LetsConnectPopup";
 import LetsConnectIconWhite from "@/public/static/images/account_circle_white.svg";
+import { addLanguageToFormData, addAffiliationToFormData } from "@/lib/utils/formDataUtils";
 
 interface ProfileEditDesktopViewProps {
   selectedAvatar: any;
@@ -816,13 +817,9 @@ export default function ProfileEditDesktopView(
                   value=""
                   onChange={(e) => {
                     if (e.target.value) {
-                      setFormData({
-                        ...formData,
-                        language: [
-                          ...(formData.language || []),
-                          { id: Number(e.target.value), proficiency: "3" },
-                        ],
-                      });
+                      const languageId = Number(e.target.value);
+                      const languageName = languagesData[e.target.value];
+                      setFormData(addLanguageToFormData(formData, languageId, "3", languageName));
                     }
                   }}
                   className={`w-full px-4 py-2 rounded-[16px] font-[Montserrat] text-[24px] appearance-none ${
@@ -971,17 +968,8 @@ export default function ProfileEditDesktopView(
                 <select
                   value=""
                   onChange={(e) => {
-                    if (
-                      e.target.value &&
-                      !formData.affiliation?.includes(e.target.value)
-                    ) {
-                      setFormData({
-                        ...formData,
-                        affiliation: [
-                          ...(formData.affiliation || []),
-                          e.target.value,
-                        ],
-                      });
+                    if (e.target.value) {
+                      setFormData(addAffiliationToFormData(formData, e.target.value));
                     }
                   }}
                   className={`w-full px-4 py-2 rounded-[16px] font-[Montserrat] text-[24px] appearance-none ${

--- a/src/app/(auth)/profile/edit/components/ProfileEditMobileView.tsx
+++ b/src/app/(auth)/profile/edit/components/ProfileEditMobileView.tsx
@@ -70,6 +70,7 @@ import { useRouter } from "next/navigation";
 import BadgesCarousel from "@/components/BadgesCarousel";
 import { useBadges } from "@/contexts/BadgesContext";
 import LetsConnectIconWhite from "@/public/static/images/account_circle_white.svg";
+import { addLanguageToFormData } from "@/lib/utils/formDataUtils";
 
 interface ProfileEditMobileViewProps {
   selectedAvatar: any;
@@ -848,13 +849,9 @@ export default function ProfileEditMobileView(
                     value=""
                     onChange={(e) => {
                       if (e.target.value) {
-                        setFormData({
-                          ...formData,
-                          language: [
-                            ...(formData.language || []),
-                            { id: Number(e.target.value), proficiency: "3" },
-                          ],
-                        });
+                        const languageId = Number(e.target.value);
+                        const languageName = languages[e.target.value];
+                        setFormData(addLanguageToFormData(formData, languageId, "3", languageName));
                       }
                     }}
                     className={`w-full px-4 py-2 rounded-[4px] font-[Montserrat] text-[12px] appearance-none ${

--- a/src/lib/utils/formDataUtils.ts
+++ b/src/lib/utils/formDataUtils.ts
@@ -1,0 +1,101 @@
+import { LanguageProficiency } from "@/types/language";
+
+// Utility functions to avoid duplicates in form data
+export const addUniqueItem = <T,>(array: T[], item: T): T[] => {
+  if (!array.includes(item)) {
+    return [...array, item];
+  }
+  return array;
+};
+
+export const addUniqueItems = <T,>(array: T[], items: T[]): T[] => {
+  const uniqueItems = items.filter(item => !array.includes(item));
+  return [...array, ...uniqueItems];
+};
+
+export const addUniqueCapacity = (capacities: number[], capacityId: number): number[] => {
+  return addUniqueItem(capacities, capacityId);
+};
+
+export const addUniqueCapacities = (capacities: number[], newCapacities: number[]): number[] => {
+  return addUniqueItems(capacities, newCapacities);
+};
+
+export const addUniqueLanguage = (languages: LanguageProficiency[], language: LanguageProficiency): LanguageProficiency[] => {
+  // Check if language with same id already exists
+  const existingLanguage = languages.find(lang => lang.id === language.id);
+  if (!existingLanguage) {
+    return [...languages, language];
+  }
+  return languages;
+};
+
+export const addUniqueLanguages = (languages: LanguageProficiency[], newLanguages: LanguageProficiency[]): LanguageProficiency[] => {
+  const uniqueLanguages = newLanguages.filter(newLang => 
+    !languages.some(existingLang => existingLang.id === newLang.id)
+  );
+  return [...languages, ...uniqueLanguages];
+};
+
+export const addUniqueAffiliation = (affiliations: string[], affiliationId: string): string[] => {
+  return addUniqueItem(affiliations, affiliationId);
+};
+
+export const addUniqueAffiliations = (affiliations: string[], newAffiliations: string[]): string[] => {
+  return addUniqueItems(affiliations, newAffiliations);
+};
+
+export const addUniqueTerritory = (territories: string[], territoryId: string): string[] => {
+  return addUniqueItem(territories, territoryId);
+};
+
+export const addUniqueProject = (projects: string[], project: string): string[] => {
+  return addUniqueItem(projects, project);
+};
+
+export const addUniqueProjects = (projects: string[], newProjects: string[]): string[] => {
+  return addUniqueItems(projects, newProjects);
+};
+
+// Functions for adding languages and affiliations in view components
+export const addLanguageToFormData = (
+  formData: any, 
+  languageId: number, 
+  proficiency: string = "3",
+  languageName?: string
+): any => {
+  const newLanguage: LanguageProficiency = { 
+    id: languageId, 
+    proficiency,
+    name: languageName || `Language ${languageId}`
+  };
+  const currentLanguages = formData.language || [];
+  
+  // Check if language already exists
+  const existingLanguage = currentLanguages.find((lang: LanguageProficiency) => lang.id === languageId);
+  if (existingLanguage) {
+    return formData; // Don't add if already exists
+  }
+  
+  return {
+    ...formData,
+    language: [...currentLanguages, newLanguage],
+  };
+};
+
+export const addAffiliationToFormData = (
+  formData: any, 
+  affiliationId: string
+): any => {
+  const currentAffiliations = formData.affiliation || [];
+  
+  // Check if affiliation already exists
+  if (currentAffiliations.includes(affiliationId)) {
+    return formData; // Don't add if already exists
+  }
+  
+  return {
+    ...formData,
+    affiliation: [...currentAffiliations, affiliationId],
+  };
+}; 

--- a/src/types/language.ts
+++ b/src/types/language.ts
@@ -1,5 +1,6 @@
 export interface LanguageProficiency {
   id: number;
+  name?: string;
   proficiency: string;
 }
 


### PR DESCRIPTION
- avoid duplicated data when integrating with lets connect
- set advanced as default language proficiency
- keep user's form data as default and not override with lets connect integration data. (keep both data)