### PR TITLE
Return with no avatar option and fix avatar popup layout issue

### DIFF
--- a/src/app/(auth)/profile/components/AvatarSelectionPopup.tsx
+++ b/src/app/(auth)/profile/components/AvatarSelectionPopup.tsx
@@ -40,6 +40,12 @@ export default function AvatarSelectionPopup({
     onClose();
   };
 
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   if (isLoading) {
     return (
       <div className="fixed inset-0 bg-black bg-opacity-50 z-40 flex items-center justify-center">
@@ -53,11 +59,11 @@ export default function AvatarSelectionPopup({
   if (isMobile) {
     return (
       <>
-        <div className="fixed inset-0 bg-black bg-opacity-50 z-40" />
+        <div className="fixed inset-0 bg-black bg-opacity-50 z-40" onClick={handleBackdropClick} />
         <div
           className={`fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 ${
             darkMode ? 'bg-[#053749] text-white' : 'bg-white text-[#053749]'
-          } z-50 rounded-lg shadow-xl h-[477px] w-[273px] flex flex-col`}
+          } z-50 rounded-lg shadow-xl h-[477px] w-[273px] flex flex-col max-h-[90vh]`}
         >
           <div className="flex justify-between items-center p-6 border-b border-gray-200">
             <h2 className={`font-[Montserrat] text-[16px] font-bold`}>
@@ -120,19 +126,19 @@ export default function AvatarSelectionPopup({
 
   return (
     <>
-      <div className="fixed inset-0 bg-black bg-opacity-50 z-40" />
+      <div className="fixed inset-0 bg-black bg-opacity-50 z-40" onClick={handleBackdropClick} />
       <div
-        className={`fixed w-[600px] h-[919px] top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 overflow-y-auto ${
+        className={`fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 max-w-[90vw] max-h-[90vh] w-[600px] ${
           darkMode ? 'bg-[#005B3F] text-white' : 'bg-white text-[#053749]'
         } z-50 rounded-lg shadow-xl flex flex-col`}
       >
-        <div className="flex justify-center items-center p-6 border-b border-gray-200">
-          <h2 className={`font-[Montserrat] text-[48px] font-bold`}>
+        <div className="flex justify-center items-center p-6 border-b border-gray-200 flex-shrink-0">
+          <h2 className={`font-[Montserrat] text-[48px] font-bold text-center`}>
             {pageContent['edit-profile-choose-an-option']}
           </h2>
         </div>
 
-        <div className="flex overflow-y-auto scrollbar-hide flex-1 p-6 justify-center">
+        <div className="flex overflow-y-auto scrollbar-hide flex-1 p-6 justify-center min-h-0">
           <div className="grid grid-cols-2 gap-4 w-fit">
             {avatars?.map(avatar => (
               <button
@@ -161,7 +167,7 @@ export default function AvatarSelectionPopup({
           </div>
         </div>
 
-        <div className="p-6 border-t border-gray-200">
+        <div className="p-6 border-t border-gray-200 flex-shrink-0">
           <div className="flex gap-4">
             <BaseButton
               onClick={onClose}

--- a/src/app/(auth)/profile/components/AvatarSelectionPopup.tsx
+++ b/src/app/(auth)/profile/components/AvatarSelectionPopup.tsx
@@ -8,8 +8,8 @@ import { useApp } from '@/contexts/AppContext';
 
 interface AvatarSelectionPopupProps {
   onClose: () => void;
-  onSelect: (avatarId: number) => void;
-  selectedAvatarId: number;
+  onSelect: (avatarId: number | null) => void;
+  selectedAvatarId: number | null;
   onUpdate?: () => void;
 }
 
@@ -21,8 +21,16 @@ export default function AvatarSelectionPopup({
 }: AvatarSelectionPopupProps) {
   const { avatars, isLoading } = useAvatars();
   const { pageContent, isMobile } = useApp();
-  const [tempSelectedId, setTempSelectedId] = useState(selectedAvatarId);
+  const [tempSelectedId, setTempSelectedId] = useState<number | null>(selectedAvatarId);
   const { darkMode } = useTheme();
+
+  // Create virtual avatar for the "no avatar" option
+  const noAvatarOption = {
+    id: null as number | null,
+    avatar_url: 'https://upload.wikimedia.org/wikipedia/commons/6/60/CapX_-_No_avatar.svg'
+  };
+
+  const allAvatars = [noAvatarOption, ...(avatars || [])];
 
   useEffect(() => {
     document.body.style.overflow = 'hidden';
@@ -76,9 +84,9 @@ export default function AvatarSelectionPopup({
 
           <div className="overflow-y-auto flex-1 p-6">
             <div className="grid grid-cols-2 gap-4">
-              {avatars?.map(avatar => (
+              {allAvatars?.map(avatar => (
                 <button
-                  key={avatar.id}
+                  key={avatar.id ?? 'no-avatar'}
                   onClick={() => setTempSelectedId(avatar.id)}
                   className="flex justify-center"
                 >
@@ -92,7 +100,7 @@ export default function AvatarSelectionPopup({
                     <div className="relative w-full h-full">
                       <Image
                         src={avatar.avatar_url}
-                        alt={`Avatar ${avatar.id}`}
+                        alt={`Avatar ${avatar.id ?? 'no-avatar'}`}
                         fill
                         className="object-contain"
                       />
@@ -140,9 +148,9 @@ export default function AvatarSelectionPopup({
 
         <div className="flex overflow-y-auto scrollbar-hide flex-1 p-6 justify-center min-h-0">
           <div className="grid grid-cols-2 gap-4 w-fit">
-            {avatars?.map(avatar => (
+            {allAvatars?.map(avatar => (
               <button
-                key={avatar.id}
+                key={avatar.id ?? 'no-avatar'}
                 onClick={() => setTempSelectedId(avatar.id)}
                 className="flex justify-center"
               >
@@ -156,7 +164,7 @@ export default function AvatarSelectionPopup({
                   <div className="relative w-full h-full">
                     <Image
                       src={avatar.avatar_url}
-                      alt={`Avatar ${avatar.id}`}
+                      alt={`Avatar ${avatar.id ?? 'no-avatar'}`}
                       fill
                       className="object-contain"
                     />

--- a/src/app/(auth)/profile/edit/components/ProfileEditDesktopView.tsx
+++ b/src/app/(auth)/profile/edit/components/ProfileEditDesktopView.tsx
@@ -80,7 +80,7 @@ import {
 
 interface ProfileEditDesktopViewProps {
   selectedAvatar: any;
-  handleAvatarSelect: (avatarId: number) => void;
+  handleAvatarSelect: (avatarId: number | null) => void;
   showAvatarPopup: boolean;
   setShowAvatarPopup: (show: boolean) => void;
   handleWikidataClick: (newWikidataSelected: boolean) => void;

--- a/src/app/(auth)/profile/edit/components/ProfileEditMainWrapper.tsx
+++ b/src/app/(auth)/profile/edit/components/ProfileEditMainWrapper.tsx
@@ -143,7 +143,10 @@ export default function EditProfilePage() {
   const { allCapacities: capacities, loading: isLoadingAllCapacities } = useAllCapacities(token);
 
   const [showAvatarPopup, setShowAvatarPopup] = useState(false);
-  const [selectedAvatar, setSelectedAvatar] = useState({
+  const [selectedAvatar, setSelectedAvatar] = useState<{
+    id: number | null;
+    src: string;
+  }>({
     id: 0,
     src: NoAvatarIcon,
   });
@@ -446,7 +449,7 @@ export default function EditProfilePage() {
     }
   };
 
-  const handleAvatarSelect = (avatarId: number) => {
+  const handleAvatarSelect = (avatarId: number | null) => {
     setFormData(prev => ({
       ...prev,
       avatar: avatarId,
@@ -456,7 +459,10 @@ export default function EditProfilePage() {
 
     setIsWikidataSelected(false);
 
-    const selectedAvatarUrl = avatars?.find(avatar => avatar.id === avatarId)?.avatar_url;
+    // Se avatarId for null, usar a imagem NoAvatar
+    const selectedAvatarUrl = avatarId === null 
+      ? 'https://upload.wikimedia.org/wikipedia/commons/6/60/CapX_-_No_avatar.svg'
+      : avatars?.find(avatar => avatar.id === avatarId)?.avatar_url;
 
     setSelectedAvatar({
       id: avatarId,

--- a/src/app/(auth)/profile/edit/components/ProfileEditMobileView.tsx
+++ b/src/app/(auth)/profile/edit/components/ProfileEditMobileView.tsx
@@ -78,7 +78,7 @@ import {
 
 interface ProfileEditMobileViewProps {
   selectedAvatar: any;
-  handleAvatarSelect: (avatarId: number) => void;
+  handleAvatarSelect: (avatarId: number | null) => void;
   showAvatarPopup: boolean;
   handleWikidataClick: (newWikidataSelected: boolean) => void;
   setShowAvatarPopup: (show: boolean) => void;

--- a/src/types/avatar.ts
+++ b/src/types/avatar.ts
@@ -1,4 +1,4 @@
 export interface Avatar {
-  id: number;
+  id: number | null;
   avatar_url: string;
 }


### PR DESCRIPTION
# Add "No Avatar" option to avatar selection popup

## Changes

- **Added "No Avatar" option**: The avatar selection popup now includes a "No Avatar" option as the first choice, using the Wikimedia Commons image: `https://upload.wikimedia.org/wikipedia/commons/6/60/CapX_-_No_avatar.svg`

- **Updated type definitions**: Modified `Avatar` interface to support `null` ID for the virtual "no avatar" option

- **Fixed avatar removal**: When selecting "No Avatar", the system now sends `null` to the backend instead of ID `0`, which was causing validation errors

## Technical Details

- Modified `AvatarSelectionPopup` component to include a virtual avatar with `id: null`
- Updated `handleAvatarSelect` function to accept `number | null` parameter
- Updated type definitions in `ProfileEditMainWrapper`, `ProfileEditMobileView`, and `ProfileEditDesktopView`
- The "No Avatar" option appears first in the grid, before all other avatars

## Testing

- Users can now select "No Avatar" to remove their current avatar
- The selection properly saves to the backend without validation errors
- The UI correctly displays the Wikimedia Commons image for the "No Avatar" option