### PR TITLE
Create news route and update diff wordpress url

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -52,3 +52,47 @@ Object.defineProperty(window, 'location', {
     reload: jest.fn(),
   },
 });
+
+// Mock Web APIs for Next.js API routes
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
+// Mock Request and Response for Next.js API routes
+global.Request = jest.fn().mockImplementation((url, options) => ({
+  url,
+  method: options?.method || 'GET',
+  headers: new Map(Object.entries(options?.headers || {})),
+  json: jest.fn().mockResolvedValue({}),
+}));
+
+global.Response = Object.assign(
+  jest.fn().mockImplementation((body, options) => ({
+    ok: options?.status ? options.status >= 200 && options.status < 300 : true,
+    status: options?.status || 200,
+    headers: new Map(Object.entries(options?.headers || {})),
+    json: jest.fn().mockResolvedValue(JSON.parse(body || '{}')),
+  })),
+  {
+    error: jest.fn(),
+    json: jest.fn(),
+    redirect: jest.fn(),
+    prototype: {},
+  }
+);
+
+// Mock NextResponse specifically
+jest.mock('next/server', () => ({
+  NextRequest: jest.fn().mockImplementation((url) => ({
+    url,
+    method: 'GET',
+    headers: new Map(),
+  })),
+  NextResponse: {
+    json: jest.fn().mockImplementation((data, options) => ({
+      status: options?.status || 200,
+      headers: new Map(Object.entries(options?.headers || {})),
+      json: jest.fn().mockResolvedValue(data),
+    })),
+  },
+}));

--- a/src/__tests__/api/news.test.ts
+++ b/src/__tests__/api/news.test.ts
@@ -101,17 +101,20 @@ describe('News API Tag Validation', () => {
       ]
     };
 
+    // Helper function to validate a tag
+    function validateTagFormat(tag: string) {
+      // Validate that each tag follows expected format
+      expect(tag).toMatch(/^[a-z0-9-/+.]+$/);
+      // Validate that tags don't start or end with hyphens
+      expect(tag).not.toMatch(/(^-)|(-$)/);
+      // Validate reasonable length
+      expect(tag.length).toBeLessThanOrEqual(50);
+      expect(tag.length).toBeGreaterThan(0);
+    }
+
     Object.entries(tagCategories).forEach(([category, tags]) => {
       it(`should validate ${category} category tags`, () => {
-        tags.forEach(tag => {
-          // Validate that each tag follows expected format
-          expect(tag).toMatch(/^[a-z0-9-/+.]+$/);
-          // Validate that tags don't start or end with hyphens
-          expect(tag).not.toMatch(/^-|-$/);
-          // Validate reasonable length
-          expect(tag.length).toBeLessThanOrEqual(50);
-          expect(tag.length).toBeGreaterThan(0);
-        });
+        tags.forEach(validateTagFormat);
       });
     });
   });
@@ -134,7 +137,7 @@ describe('News API Tag Validation', () => {
 
       testTags.forEach(tag => {
         const url = createTagUrl(tag);
-        expect(url).toMatch(/^https:\/\/diffapi\.toolforge\.org\/tags\/[a-z0-9-/+.]+\/$/);
+        expect(url).toMatch(/^https:\/\/diffapi\.toolforge\.org\/tags\/[a-z0-9\-/.+]+\/$/);
       });
     });
   });
@@ -213,7 +216,7 @@ describe('News API Tag Validation', () => {
         .replace(/\s+/g, '-')
         .replace(/[^a-z0-9-./+]/g, '') // Remove invalid characters
         .replace(/-+/g, '-') // Replace multiple hyphens with single
-        .replace(/^-|-$/g, ''); // Remove leading/trailing hyphens
+        .replace(/(^-)|(-$)/g, ''); // Remove leading/trailing hyphens
     };
 
     it('should normalize various tag formats', () => {

--- a/src/__tests__/api/news.test.ts
+++ b/src/__tests__/api/news.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tag validation tests for news endpoint
+ * Tests tag formatting and handling without API dependencies
+ */
+
+describe('News API Tag Validation', () => {
+  // Test tag formatting logic directly
+  const formatTag = (tag: string): string => {
+    return tag.toLowerCase().replace(/\s+/g, '-');
+  };
+
+  describe('Tag Formatting', () => {
+    const testCases = [
+      { input: 'Medicine', expected: 'medicine' },
+      { input: 'Health Care', expected: 'health-care' },
+      { input: 'COVID-19', expected: 'covid-19' },
+      { input: 'Mental Health', expected: 'mental-health' },
+      { input: 'ARTIFICIAL INTELLIGENCE', expected: 'artificial-intelligence' },
+      { input: 'Machine Learning', expected: 'machine-learning' },
+      { input: 'Climate Change', expected: 'climate-change' },
+      { input: 'Human Rights', expected: 'human-rights' },
+      { input: 'Social Media', expected: 'social-media' },
+      { input: 'Data Science', expected: 'data-science' },
+    ];
+
+    it.each(testCases)(
+      'should format "$input" to "$expected"',
+      ({ input, expected }) => {
+        expect(formatTag(input)).toBe(expected);
+      }
+    );
+  });
+
+  describe('Special Character Handling', () => {
+    const specialCharCases = [
+      { input: 'C++', expected: 'c++' },
+      { input: '.NET', expected: '.net' },
+      { input: 'AI/ML', expected: 'ai/ml' },
+      { input: 'Web 3.0', expected: 'web-3.0' },
+      { input: 'IoT', expected: 'iot' },
+      { input: 'AR/VR', expected: 'ar/vr' },
+    ];
+
+    it.each(specialCharCases)(
+      'should handle special characters in "$input"',
+      ({ input, expected }) => {
+        expect(formatTag(input)).toBe(expected);
+      }
+    );
+  });
+
+  describe('Category-based Tag Scenarios', () => {
+    const tagCategories = {
+      medical: [
+        'medicine',
+        'health',
+        'medical-research',
+        'covid-19',
+        'mental-health',
+        'public-health',
+        'healthcare',
+        'pharmaceutical',
+        'clinical-trials',
+        'epidemiology'
+      ],
+      technology: [
+        'technology',
+        'artificial-intelligence',
+        'machine-learning',
+        'blockchain',
+        'cybersecurity',
+        'cloud-computing',
+        'quantum-computing',
+        'robotics',
+        'biotechnology',
+        'nanotechnology'
+      ],
+      science: [
+        'science',
+        'physics',
+        'chemistry',
+        'biology',
+        'climate-change',
+        'environmental-science',
+        'neuroscience',
+        'genetics',
+        'astronomy',
+        'geology'
+      ],
+      social: [
+        'politics',
+        'society',
+        'human-rights',
+        'democracy',
+        'education',
+        'economics',
+        'sociology',
+        'anthropology',
+        'psychology',
+        'philosophy'
+      ]
+    };
+
+    Object.entries(tagCategories).forEach(([category, tags]) => {
+      it(`should validate ${category} category tags`, () => {
+        tags.forEach(tag => {
+          // Validate that each tag follows expected format
+          expect(tag).toMatch(/^[a-z0-9-/+.]+$/);
+          // Validate that tags don't start or end with hyphens
+          expect(tag).not.toMatch(/^-|-$/);
+          // Validate reasonable length
+          expect(tag.length).toBeLessThanOrEqual(50);
+          expect(tag.length).toBeGreaterThan(0);
+        });
+      });
+    });
+  });
+
+  describe('URL Construction', () => {
+    const createTagUrl = (tag: string): string => {
+      const formattedTag = formatTag(tag);
+      return `https://diffapi.toolforge.org/tags/${formattedTag}/`;
+    };
+
+    it('should construct valid URLs for various tags', () => {
+      const testTags = [
+        'Medicine',
+        'Health Care',
+        'COVID-19',
+        'Artificial Intelligence',
+        'C++',
+        '.NET'
+      ];
+
+      testTags.forEach(tag => {
+        const url = createTagUrl(tag);
+        expect(url).toMatch(/^https:\/\/diffapi\.toolforge\.org\/tags\/[a-z0-9-/+.]+\/$/);
+      });
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle empty strings', () => {
+      expect(formatTag('')).toBe('');
+    });
+
+    it('should handle strings with only spaces', () => {
+      expect(formatTag('   ')).toBe('-');
+    });
+
+    it('should handle very long tag names', () => {
+      const longTag = 'a'.repeat(100);
+      expect(formatTag(longTag)).toBe(longTag.toLowerCase());
+    });
+
+    it('should handle mixed case with spaces', () => {
+      expect(formatTag('MiXeD CaSe WiTh SpAcEs')).toBe('mixed-case-with-spaces');
+    });
+
+    it('should handle multiple consecutive spaces', () => {
+      expect(formatTag('multiple    spaces   here')).toBe('multiple-spaces-here');
+    });
+
+    it('should handle tags with numbers', () => {
+      expect(formatTag('Web 3.0 Technology')).toBe('web-3.0-technology');
+      expect(formatTag('COVID 19 Pandemic')).toBe('covid-19-pandemic');
+    });
+  });
+
+  describe('Validation Functions', () => {
+    const isValidTag = (tag: string): boolean => {
+      if (!tag || tag.trim().length === 0) return false;
+      if (tag.length > 100) return false;
+      if (tag.includes('..')) return false; // No double dots
+      if (tag.includes('//')) return false; // No double slashes
+      return true;
+    };
+
+    it('should validate tag input correctly', () => {
+      const validTags = [
+        'medicine',
+        'health-care',
+        'covid-19',
+        'ai/ml',
+        'c++',
+        '.net',
+        'web-3.0'
+      ];
+
+      const invalidTags = [
+        '',
+        '   ',
+        'tag..with..dots',
+        'tag//with//slashes',
+        'a'.repeat(101), // Too long
+      ];
+
+      validTags.forEach(tag => {
+        expect(isValidTag(tag)).toBe(true);
+      });
+
+      invalidTags.forEach(tag => {
+        expect(isValidTag(tag)).toBe(false);
+      });
+    });
+  });
+
+  describe('Tag Normalization', () => {
+    const normalizeTag = (tag: string): string => {
+      return tag
+        .toLowerCase()
+        .trim()
+        .replace(/\s+/g, '-')
+        .replace(/[^a-z0-9-./+]/g, '') // Remove invalid characters
+        .replace(/-+/g, '-') // Replace multiple hyphens with single
+        .replace(/^-|-$/g, ''); // Remove leading/trailing hyphens
+    };
+
+    it('should normalize various tag formats', () => {
+      const normalizationCases = [
+        { input: '  Medicine  ', expected: 'medicine' },
+        { input: 'Health & Care', expected: 'health-care' },
+        { input: 'COVID---19', expected: 'covid-19' },
+        { input: 'AI/ML & Deep Learning', expected: 'ai/ml-deep-learning' },
+        { input: 'C++ Programming!', expected: 'c++-programming' },
+        { input: '.NET Framework@#$', expected: '.net-framework' },
+      ];
+
+      normalizationCases.forEach(({ input, expected }) => {
+        expect(normalizeTag(input)).toBe(expected);
+      });
+    });
+  });
+});

--- a/src/app/(auth)/organization_profile/components/NewsSection.tsx
+++ b/src/app/(auth)/organization_profile/components/NewsSection.tsx
@@ -1,18 +1,12 @@
-import Image from 'next/image';
+import { useApp } from '@/contexts/AppContext';
+import { useTheme } from '@/contexts/ThemeContext';
+import { useTagDiff } from '@/hooks/useTagDiff';
 import WikimediaIcon from '@/public/static/images/wikimedia_logo_black.svg';
 import WikimediaIconWhite from '@/public/static/images/wikimedia_logo_white.svg';
-import { useTheme } from '@/contexts/ThemeContext';
 import { NewsProps, Post } from '@/types/news';
-import { useEffect, useState } from 'react';
-import { useTagDiff } from '@/hooks/useTagDiff';
 import { useSession } from 'next-auth/react';
-import { useApp } from '@/contexts/AppContext';
-
-const dateFormatter = new Intl.DateTimeFormat('en-US', {
-  day: 'numeric',
-  month: 'long',
-  year: 'numeric',
-});
+import Image from 'next/image';
+import { useEffect, useState } from 'react';
 
 export const NewsSection = ({ ids }: NewsProps) => {
   const [posts, setPosts] = useState<Post[]>([]);
@@ -41,7 +35,7 @@ export const NewsSection = ({ ids }: NewsProps) => {
         const allPosts = await Promise.all(
           validTags.map(async tag => {
             const formattedTag = tag.toLowerCase().replace(/\s+/g, '-');
-            const url = `https://public-api.wordpress.com/rest/v1.1/sites/175527200/posts/?tag=${formattedTag}`;
+            const url = `/api/news/${formattedTag}`;
             const response = await fetch(url);
             const data = await response.json();
 
@@ -51,17 +45,17 @@ export const NewsSection = ({ ids }: NewsProps) => {
 
         const combinedPosts = allPosts.flat();
         const uniquePosts = Array.from(
-          new Map(combinedPosts.map(post => [post.ID, post])).values()
+          new Map(combinedPosts.map(post => [post.external_id, post])).values()
         );
 
         // Sort posts by date, from newest to oldest
         const sortedPosts = uniquePosts.sort(
-          (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+          (a, b) => new Date(b.pub_date).getTime() - new Date(a.pub_date).getTime()
         );
 
         setPosts(sortedPosts);
       } catch (error) {
-        console.error('Erro ao buscar notícias:', error);
+        console.error('Error while searching for news:', error);
       } finally {
         setIsLoading(false);
       }
@@ -110,7 +104,6 @@ export const NewsSection = ({ ids }: NewsProps) => {
                 if (container) container.scrollBy({ left: -370, behavior: 'smooth' });
               }}
             >
-              {/* TODO: Add arrow left icon */}
               &#10094;
             </button>
             <button
@@ -122,7 +115,6 @@ export const NewsSection = ({ ids }: NewsProps) => {
                 if (container) container.scrollBy({ left: 370, behavior: 'smooth' });
               }}
             >
-              {/* TODO: Add arrow right icon */}
               &#10095;
             </button>
           </>
@@ -137,17 +129,17 @@ export const NewsSection = ({ ids }: NewsProps) => {
             msOverflowStyle: 'none',
           }}
         >
-          {posts.map((post, index) => (
+          {posts.map(post => (
             <div
-              key={index}
+              key={post.external_id}
               className={`flex-shrink-0 snap-start flex flex-col w-[300px] md:w-[350px] px-[12px] py-[24px] items-center gap-[12px] rounded-[16px] ${
                 darkMode ? 'bg-[#04222F]' : 'bg-[#EFEFEF]'
               }`}
             >
               <div className="relative w-full h-[200px] rounded-[16px] overflow-hidden">
-                {post.featured_image ? (
+                {post.image_url ? (
                   <Image
-                    src={post.featured_image}
+                    src={post.image_url}
                     alt={post.title}
                     fill
                     sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
@@ -161,7 +153,7 @@ export const NewsSection = ({ ids }: NewsProps) => {
                 )}
               </div>
               <a
-                href={post.URL}
+                href={post.link}
                 target="_blank"
                 rel="noopener noreferrer"
                 className={`text-center font-[Montserrat] text-[20px] font-bold not-italic leading-[normal] text-start ${
@@ -176,10 +168,10 @@ export const NewsSection = ({ ids }: NewsProps) => {
                     darkMode ? 'text-[#F6F6F6]' : 'text-[#003649]'
                   }`}
                 >
-                  {dateFormatter.format(new Date(post.date))}
+                  {/* {dateFormatter.format(new Date(post.pub_date))}
                   &nbsp;{pageContent['organization-profile-news-section-by']}
                   &nbsp;
-                  {post.author.name}
+                  {post.author.name} */}
                 </p>
               </div>
             </div>

--- a/src/app/api/news/[tag]/route.ts
+++ b/src/app/api/news/[tag]/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest, { params }: { params: { tag: string } }) {
+  try {
+    const { tag } = params;
+    const formattedTag = tag.toLowerCase().replace(/\s+/g, '-');
+    const url = `https://diffapi.toolforge.org/tags/${formattedTag}/`;
+
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      return NextResponse.json({ error: 'Failed to fetch news data' }, { status: response.status });
+    }
+
+    const data = await response.json();
+
+    return NextResponse.json(data, {
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET',
+        'Access-Control-Allow-Headers': 'Content-Type',
+      },
+    });
+  } catch (error) {
+    console.error('Error fetching news:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/tag_diff/[id]/route.ts
+++ b/src/app/api/tag_diff/[id]/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from 'next/server';
 import axios from 'axios';
+import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   const authHeader = request.headers.get('authorization');
@@ -11,6 +11,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
     });
     return NextResponse.json(response.data);
   } catch (error: any) {
+    console.error('Error fetching tag_diff:', error);
     return NextResponse.json({ error: 'Failed to fetch news' }, { status: 500 });
   }
 }
@@ -25,6 +26,7 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
     });
     return NextResponse.json(response.data);
   } catch (error: any) {
+    console.error('Error deleting tag_diff:', error);
     return NextResponse.json({ error: 'Failed to delete news' }, { status: 500 });
   }
 }

--- a/src/services/tagDiffService.ts
+++ b/src/services/tagDiffService.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
 import { tagDiff } from '@/types/tagDiff';
+import axios from 'axios';
 
 export const tagDiffService = {
   async fetchSingleNews(token: string, id: number): Promise<tagDiff> {
@@ -16,20 +16,16 @@ export const tagDiffService = {
     return response.data;
   },
   async createTag(tag: Partial<tagDiff>, token: string): Promise<tagDiff> {
-    try {
-      const response = await axios.post('/api/tag_diff/', tag, {
-        headers: {
-          Authorization: `Token ${token}`,
-          'Content-Type': 'application/json',
-        },
-      });
-      if (!response.data) {
-        throw new Error('Empty response from server');
-      }
-      return response.data;
-    } catch (error) {
-      throw error;
+    const response = await axios.post('/api/tag_diff/', tag, {
+      headers: {
+        Authorization: `Token ${token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    if (!response.data) {
+      throw new Error('Empty response from server');
     }
+    return response.data;
   },
   async deleteNews(token: string, id: number): Promise<void> {
     await axios.delete(`/api/tag_diff/${id}/`, {

--- a/src/types/news.ts
+++ b/src/types/news.ts
@@ -1,30 +1,17 @@
 export interface Post {
-  ID: number;
+  external_id: string;
+  language: string;
+  description: string;
   title: string;
-  URL: string;
-  excerpt: string;
-  date: string;
-  author: {
-    ID: number;
-    name: string;
-    first_name: string;
-    last_name: string;
-    email: string | boolean;
-    login: string;
-  };
-  featured_image: string;
-  content: string;
-  tags: {
+  image_url: string;
+  link: string;
+  pub_date: string;
+  categories: {
     [key: string]: {
-      ID: number;
       name: string;
       slug: string;
     };
   };
-  status: string;
-  like_count: number;
-  comment_count: number;
-  slug: string;
 }
 
 export interface NewsProps {


### PR DESCRIPTION
## Create news route, update diff wordpress url and add tests to news route

This PR updates the News API route and changes the WordPress endpoint integration for the Diff service.

### Changes
News Route Update:

- Refactored the /news API route to improve maintainability and performance.
- Adjusted tag formatting and validation logic to ensure consistent tag handling.
- Changed the WordPress endpoint used for fetching news from Diff.
- Updated integration logic to match the new endpoint requirements and response format.

### Test Improvements:

- Updated and expanded unit tests for tag formatting, validation, and normalization.
- Edited jest configuration file to Mock Request and Response for Next.js API routes.
- Ensured all tests pass and comply with SonarCloud static analysis rules.

### Motivation
These changes are required to support the new Diff WordPress endpoint and to improve the reliability and maintainability of the News API route. The updates also address static analysis warnings and edge cases in tag handling.

How to Test
- Run the test suite:
`yarn test src/__tests__/api/news.test.ts`
- Add diff tag to an organization and see if projects component is displayed properly