### PR TITLE
Fix formatting in mbQueryText string

### DIFF
--- a/src/lib/utils/capacitiesUtils.ts
+++ b/src/lib/utils/capacitiesUtils.ts
@@ -289,8 +289,10 @@ export const fetchMetabase = async (codes: any, language: string): Promise<Capac
     }
 
     const mbQueryText = `PREFIX wbt:<https://metabase.wikibase.cloud/prop/direct/>
+      PREFIX wb: <https://metabase.wikibase.cloud/entity/>
       SELECT ?item ?itemLabel ?itemDescription ?value WHERE {
       VALUES ?value {${codes.map((code: any) => `"${code.wd_code}"`).join(' ')}}
+      ?item wbt:P5 wb:Q34531.
       ?item wbt:P67/wbt:P1 ?value.
       SERVICE wikibase:label { bd:serviceParam wikibase:language '${language},en'. }}`;
 


### PR DESCRIPTION
This pull request updates the SPARQL query in the `fetchMetabase` function to improve how items are filtered and retrieved from the Metabase Wikibase. The main change is the addition of a new triple pattern and prefix to ensure that only items of a specific type are selected.

Query improvements:

* Added the `wb:` prefix to the SPARQL query and included a triple pattern `?item wbt:P5 wb:Q34531.` to filter items by a specific entity type, ensuring more accurate query results.