### PR TITLE
Fix saving profile error

### DIFF
--- a/src/app/(auth)/feed/page.tsx
+++ b/src/app/(auth)/feed/page.tsx
@@ -235,9 +235,7 @@ export default function FeedPage() {
   const resolveSaveType = (type: any) => {
     if (Array.isArray(type)) {
       // Prefer Sharer if present; otherwise use the first
-      return type.includes(ProfileCapacityType.Sharer)
-        ? ProfileCapacityType.Sharer
-        : type[0];
+      return type.includes(ProfileCapacityType.Sharer) ? ProfileCapacityType.Sharer : type[0];
     }
     return type;
   };

--- a/src/app/(auth)/feed/page.tsx
+++ b/src/app/(auth)/feed/page.tsx
@@ -229,6 +229,19 @@ export default function FeedPage() {
     return <LoadingState fullScreen={true} />;
   }
 
+  // Ensure save type is a single value even when the profile is multi-type
+  // To avoid errors when saving the profile
+  // TODO: Fix this in the future, removing type from backend
+  const resolveSaveType = (type: any) => {
+    if (Array.isArray(type)) {
+      // Prefer Sharer if present; otherwise use the first
+      return type.includes(ProfileCapacityType.Sharer)
+        ? ProfileCapacityType.Sharer
+        : type[0];
+    }
+    return type;
+  };
+
   const handleToggleSaved = (profile: any) => {
     try {
       if (profile.isSaved) {
@@ -241,7 +254,8 @@ export default function FeedPage() {
           showSnackbar(pageContent['saved-profiles-delete-success'], 'success');
         }
       } else {
-        createSavedItem('user', profile.id, profile.type);
+        const saveType = resolveSaveType(profile.type);
+        createSavedItem('user', profile.id, saveType);
         showSnackbar(pageContent['saved-profiles-add-success'], 'success');
       }
     } catch {


### PR DESCRIPTION
Avoid sending ['sharer', 'learner'] as a type for saving profile cause its not a valid type.
We actually dont use this type anymore so we could remove it from backend in the future as well.